### PR TITLE
Hide curbside and SMS UI options by default

### DIFF
--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -60,6 +60,7 @@ define(function(require) {
 						confNumbers: myOfficeData.confNumbers || [],
 						faxingNumbers: myOfficeData.faxingNumbers || [],
 						faxNumbers: myOfficeData.faxNumbers || [],
+						showCurbsideManagement: false,
 						topMessage: myOfficeData.topMessage,
 						devicesList: _.orderBy(myOfficeData.devicesData, 'count', 'desc'),
 						usersList: _.orderBy(myOfficeData.usersData, 'count', 'desc'),

--- a/submodules/myOffice/views/layout.html
+++ b/submodules/myOffice/views/layout.html
@@ -19,10 +19,12 @@
 				<div class="header-link-title">{{i18n.myOffice.topBarLinks.callerID}}</div>
 			</a>
 		{{/if}}
-		<a href="#" class="header-link curbside{{#compare mainNumbers.length "===" 0}} disabled{{/compare}}">
-			<div class="header-link-icon"><i class="monster-white fa-lg fa fa-car"></i></div>
-			<div class="header-link-title">{{i18n.myOffice.topBarLinks.curbside}}</div>
-		</a>
+		{{#if showCurbsideManagement}}
+			<a href="#" class="header-link curbside{{#compare mainNumbers.length "===" 0}} disabled{{/compare}}">
+				<div class="header-link-icon"><i class="monster-white fa-lg fa fa-car"></i></div>
+				<div class="header-link-title">{{i18n.myOffice.topBarLinks.curbside}}</div>
+			</a>
+		{{/if}}
 	</div>
 
 	<div class="dashboard-content">

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -308,7 +308,8 @@ define(function(require) {
 						sms: {
 							icon: 'fa fa-comments',
 							iconColor: 'monster-green',
-							title: self.i18n.active().users.sms.title
+							title: self.i18n.active().users.sms.title,
+							hidden: true
 						},
 						mobile_app: {
 							icon: 'fa fa-mobile',


### PR DESCRIPTION
This change gates the My Office curbside header link behind a new `showCurbsideManagement` flag set to `false`, so the link is not shown unless explicitly enabled. It also marks the users `sms` feature card as `hidden`, removing it from the visible options while keeping the configuration in place for future activation.