### PR TITLE
Disable device creation across app flows

### DIFF
--- a/app.js
+++ b/app.js
@@ -562,11 +562,7 @@ define(function(require) {
 			});
 		},
 
-		canCreateDevices: function(pAccount) {
-			var account = pAccount || _.get(monster, 'apps.auth.originalAccount', {});
-			if (account.sv_custom) {
-				return _.get(account.sv_custom, 'can_create_devices', false);
-			}
+		canCreateDevices: function() {
 			return false;
 		},
 

--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -283,8 +283,13 @@ define(function(require) {
 		 * @param  {Function} args.callback
 		 */
 		devicesRenderAdd: function(args) {
-			var self = this,
-				allowAssign = _.get(args, 'allowAssign'),
+			var self = this;
+
+			if (!self.canCreateDevices()) {
+				return;
+			}
+
+			var allowAssign = _.get(args, 'allowAssign'),
 				type = args.type,
 				callback = args.callback,
 				data = {
@@ -1227,7 +1232,7 @@ define(function(require) {
 				unassignedString = self.i18n.active().devices.unassignedDevice;
 				registeredDevices = _.filter(data.status, (device) => device.registered);
 				registeredDevicesById = _.map(registeredDevices, 'device_id'),
-				filteredAddableDeviceTypes = self.canCreateDevices() ? self.appFlags.devices.addableDeviceTypes : ['cellphone'];
+				filteredAddableDeviceTypes = self.canCreateDevices() ? self.appFlags.devices.addableDeviceTypes : [];
 
 			return {
 				countDevices: _.size(data.devices),
@@ -1548,6 +1553,11 @@ define(function(require) {
 		 */
 		devicesCreateDevice: function(deviceData, callbackSuccess, callbackError) {
 			var self = this;
+
+			if (!self.canCreateDevices()) {
+				callbackError && callbackError();
+				return;
+			}
 
 			self.callApi({
 				resource: 'device.create',

--- a/submodules/devices/views/layout.html
+++ b/submodules/devices/views/layout.html
@@ -5,24 +5,26 @@
 			<span class="count-devices">{{countDevices}}</span>
 		</div>
 
-		<div class="dropdown">
-			<a href="#" class="add-device monster-link dropdown-toggle" data-toggle="dropdown">
-				<i class="fa fa-plus-circle"></i>
-				{{i18n.devices.add }}
-			</a>
-			<ul class="dropdown-menu">
-			{{#each deviceTypesToAdd}}
-				<li>
-					<a class="create-device" data-type="{{type}}">
-						<i>
-							{{telicon icon}}
-						</i>
-						{{tryI18n @root.i18n.devices.types type}}
-					</a>
-				</li>
-			{{/each}}
-			</ul>
-		</div>
+		{{#if deviceTypesToAdd}}
+			<div class="dropdown">
+				<a href="#" class="add-device monster-link dropdown-toggle" data-toggle="dropdown">
+					<i class="fa fa-plus-circle"></i>
+					{{i18n.devices.add }}
+				</a>
+				<ul class="dropdown-menu">
+				{{#each deviceTypesToAdd}}
+					<li>
+						<a class="create-device" data-type="{{type}}">
+							<i>
+								{{telicon icon}}
+							</i>
+							{{tryI18n @root.i18n.devices.types type}}
+						</a>
+					</li>
+				{{/each}}
+				</ul>
+			</div>
+		{{/if}}
 
 		<span class="search-box pull-right">
 			<i class="fa fa-search"></i>

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1256,6 +1256,10 @@ define(function(require) {
 
 			/* Events for Devices in Users */
 			template.on('click', '.create-device', function() {
+				if (!self.canCreateDevices()) {
+					return;
+				}
+
 				var $this = $(this),
 					type = $this.data('type');
 
@@ -2147,7 +2151,7 @@ define(function(require) {
 
 			return _.merge({
 				createVmbox: true,
-				hasProvisioner: self.appFlags.common.hasProvisioner && !_.isEmpty(data.provisioners),
+				hasProvisioner: self.canCreateDevices() && self.appFlags.common.hasProvisioner && !_.isEmpty(data.provisioners),
 				listExtensions: _
 					.chain(listExtensions)
 					.keyBy('extension')
@@ -2930,6 +2934,11 @@ define(function(require) {
 		usersPromptUserCreateDevice: function(featureUser, success, error) {
 			var self = this;
 
+			if (!self.canCreateDevices()) {
+				error && error();
+				return;
+			}
+
 			monster.ui.confirm(self.i18n.active().users.mobile_app.createADevice,
 				function() {
 					self.usersCreateUserDevice(featureUser, function(device) {
@@ -2942,7 +2951,7 @@ define(function(require) {
 			);
 		},
 
-		usersCreateUserDevice: function(featureUser, callback) {
+		usersCreateUserDevice: function(featureUser, callback, error) {
 			var self = this,
 				accountId = self.accountId,
 				deviceData = {
@@ -2952,6 +2961,11 @@ define(function(require) {
 					user_id: `${featureUser.id}`
 				};
 
+			if (!self.canCreateDevices()) {
+				error && error();
+				return;
+			}
+
 			monster.request({
 				resource: 'sv.device.create',
 				data: {
@@ -2960,6 +2974,9 @@ define(function(require) {
 				},
 				success: function(device) {
 					callback && callback(device.data);
+				},
+				error: function() {
+					error && error();
 				}
 			});
 		},
@@ -4254,7 +4271,7 @@ define(function(require) {
 
 			delete formattedData.user.extra;
 
-			if (_.get(data, 'user.device.brand', 'none') === 'none') {
+			if (!self.canCreateDevices() || _.get(data, 'user.device.brand', 'none') === 'none') {
 				delete formattedData.user.device;
 				return formattedData;
 			}
@@ -4309,7 +4326,7 @@ define(function(require) {
 		usersCreate: function(args) {
 			var self = this,
 				data = args.data,
-				deviceData = _.get(data, 'user.device');
+				deviceData = self.canCreateDevices() ? _.get(data, 'user.device') : null;
 
 			delete data.user.device;
 
@@ -4632,6 +4649,12 @@ define(function(require) {
 		 */
 		usersAddUserDevice: function(args) {
 			var self = this;
+
+			if (!self.canCreateDevices()) {
+				args.hasOwnProperty('onChargesCancelled') && args.onChargesCancelled();
+				return;
+			}
+
 			self.callApi({
 				resource: 'device.create',
 				data: _.merge({

--- a/submodules/users/views/devices.html
+++ b/submodules/users/views/devices.html
@@ -22,10 +22,10 @@
 {{#isFeatureAvailable "simplevoip.users.devices.edit"}}
 	<div class="actions">
 		<a class="spare-devices monster-link pull-left" href="javascript:void(0);"><i class="fa fa-list monster-green"></i>{{ i18n.users.devices.spareDevice }}</a>
-		<div class="dropdown pull-left">
-			<a href="#" class="add-device monster-link dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus monster-green"></i>{{ i18n.users.devices.newDevice }}</a>
-			<ul class="dropdown-menu">
-				{{#canCreateDevices}}
+		{{#canCreateDevices}}
+			<div class="dropdown pull-left">
+				<a href="#" class="add-device monster-link dropdown-toggle" data-toggle="dropdown"><i class="fa fa-plus monster-green"></i>{{ i18n.users.devices.newDevice }}</a>
+				<ul class="dropdown-menu">
 					<li><a class="create-device" data-type="sip_device"><i class="icon-telicon-voip-phone"></i>{{ i18n.devices.types.sip_device }}</a></li>
 					<!-- <li><a class="create-device" data-type="cellphone"><i class="fa fa-phone"></i>{{ i18n.devices.types.cellphone }}</a></li> -->
 					<li><a class="create-device" data-type="smartphone"><i class="icon-telicon-mobile-phone"></i>{{ i18n.devices.types.smartphone }}</a></li>
@@ -37,10 +37,10 @@
 					{{#showTeammateDevice}}
 						<li><a class="create-device" data-type="teammate"><i>{{telicon "device-mst"}}</i>{{ i18n.devices.types.teammate }}</a></li>
 					{{/showTeammateDevice}}
-				{{/canCreateDevices}}
-				<li><a class="create-device" data-type="cellphone"><i class="fa fa-phone"></i>{{ i18n.devices.types.cellphone }}</a></li>
-			</ul>
-		</div>
+					<li><a class="create-device" data-type="cellphone"><i class="fa fa-phone"></i>{{ i18n.devices.types.cellphone }}</a></li>
+				</ul>
+			</div>
+		{{/canCreateDevices}}
 
 		<div class="pull-right">
 			<a class="cancel-link monster-link blue" href="javascript:void(0);">{{ i18n.cancel }}</a>


### PR DESCRIPTION
Make `canCreateDevices` return `false` globally and enforce that policy in device/user modules. This adds early exits in create handlers and API calls, prevents provisioning/device creation logic from running, and hides add-device dropdowns in both Devices and Users views when creation is not allowed.